### PR TITLE
feat: add employee dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,20 +3,61 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Quản lý dữ liệu</title>
-  <!-- Include XLSX library for parsing and exporting Excel -->
+  <title>Dashboard nhân viên</title>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
-  <!-- Tailwind CSS for basic styling; optional but makes the UI friendly -->
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
 </head>
 <body class="p-6 font-sans">
-  <h1 class="text-2xl font-bold mb-4">Quản lý dữ liệu nhân viên</h1>
+  <h1 class="text-2xl font-bold mb-4">Dashboard nhân viên</h1>
+
   <div class="flex items-center space-x-3 mb-4">
     <input type="file" id="excelFile" accept=".xlsx,.xls" class="border p-2 rounded" />
     <button id="importBtn" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded">Nhập Excel</button>
     <button id="exportBtn" class="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded">Xuất Excel</button>
   </div>
-    <div id="tableContainer" class="overflow-auto"></div>
-    <script type="module" src="js/main.js"></script>
-  </body>
-  </html>
+
+  <div id="kpiHost" class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-4"></div>
+
+  <div class="flex flex-wrap items-end gap-4 mb-4" id="filterBar">
+    <input id="searchInput" type="text" placeholder="Tìm kiếm..." class="border p-2 rounded w-full sm:w-48" />
+    <select id="filterRole" class="border p-2 rounded w-full sm:w-40">
+      <option value="">Chức danh</option>
+    </select>
+    <select id="filterStep" class="border p-2 rounded w-full sm:w-32">
+      <option value="">Bậc lương</option>
+    </select>
+    <div class="flex items-center space-x-2">
+      <input id="filterFrom" type="date" class="border p-2 rounded" />
+      <span>-</span>
+      <input id="filterTo" type="date" class="border p-2 rounded" />
+    </div>
+  </div>
+
+  <div id="tableRoot" class="overflow-auto max-h-[60vh]"></div>
+
+  <!-- Modal chỉnh sửa -->
+  <div id="editModal" class="fixed inset-0 bg-black bg-opacity-40 hidden items-center justify-center">
+    <div class="bg-white p-6 rounded shadow-lg w-full max-w-lg">
+      <h2 class="text-xl mb-4">Chỉnh sửa nhân viên</h2>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <label class="text-sm">Họ tên<input id="mName" class="border p-2 rounded w-full" /></label>
+        <label class="text-sm">Chức danh<input id="mRole" class="border p-2 rounded w-full" /></label>
+        <label class="text-sm">Bậc lương<input id="mStep" type="number" class="border p-2 rounded w-full" /></label>
+        <label class="text-sm">Hệ số<input id="mCoef" type="number" step="0.01" class="border p-2 rounded w-full" /></label>
+        <label class="text-sm">Ngày hưởng hiện tại<input id="mCurrent" type="date" class="border p-2 rounded w-full" /></label>
+        <label class="text-sm">Ngày sinh<input id="mBirth" type="date" class="border p-2 rounded w-full" /></label>
+        <div class="text-sm col-span-full"><label>Ghi chú<textarea id="mNote" class="border p-2 rounded w-full"></textarea></label></div>
+        <div class="text-sm">Ngày tăng lương kế: <span id="mNext" class="font-semibold"></span></div>
+        <div class="text-sm">Còn lại (tháng): <span id="mRemain" class="font-semibold"></span></div>
+        <div class="text-sm">Ngày nghỉ hưu: <span id="mRetire" class="font-semibold"></span></div>
+      </div>
+      <div class="mt-4 text-right space-x-3">
+        <button id="mCancel" class="px-4 py-2 border rounded">Hủy</button>
+        <button id="mSave" class="px-4 py-2 bg-blue-500 text-white rounded">Lưu</button>
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="js/ui.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Tailwind-based dashboard layout with KPI cards, filters, and editable employee table
- implement modal editor auto-calculating next salary raise and retirement date
- enable Excel import/export for new fields

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b95567366883258c4e7104555db459