### PR TITLE
feat: handle complex excel headers

### DIFF
--- a/js/parser.test.js
+++ b/js/parser.test.js
@@ -68,3 +68,52 @@ describe('parseExcelFile simple format', () => {
   });
 });
 
+describe('parseExcelFile with multi-row headers', () => {
+  test('skips top metadata and merges header rows', async () => {
+    const aoa = [
+      ['UBND something', 'Trường A'],
+      ['Some other line'],
+      ['STT', 'Họ tên', 'Ngày sinh', 'Chức vụ', 'Trường/Đơn vị', 'Phụ cấp', '', 'Hệ số lương', '', 'Ghi chú'],
+      ['', '', '', '', '', 'Chức vụ', 'Ngày hưởng', 'Hiện hưởng', 'Ngày hưởng hiện tại', ''],
+      [1, 'Nguyễn Văn A', '01/01/1980', 'Giáo viên', 'Trường A', '0.2', '01/01/2020', 3.0, '01/01/2020', ''],
+      [2, 'Trần Thị B', '02/02/1985', 'Giáo viên', 'Trường B', '0.3', '01/03/2021', 3.1, '01/03/2021', 'ghi chú']
+    ];
+
+    const ws = XLSX.utils.aoa_to_sheet(aoa);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, 'Sheet1');
+    const buf = XLSX.write(wb, { type: 'buffer', bookType: 'xlsx' });
+
+    global.XLSX = XLSX;
+    const fakeFile = { arrayBuffer: async () => buf };
+    const parsed = await parseExcelFile(fakeFile);
+
+    expect(parsed).toEqual([
+      {
+        'STT': 1,
+        'Họ tên': 'Nguyễn Văn A',
+        'Ngày sinh': '01/01/1980',
+        'Chức vụ': 'Giáo viên',
+        'Trường/Đơn vị': 'Trường A',
+        'Phụ cấp Chức vụ': '0.2',
+        'Phụ cấp Ngày hưởng': '01/01/2020',
+        'Hệ số lương Hiện hưởng': 3.0,
+        'Hệ số lương Ngày hưởng hiện tại': '01/01/2020',
+        'Ghi chú': ''
+      },
+      {
+        'STT': 2,
+        'Họ tên': 'Trần Thị B',
+        'Ngày sinh': '02/02/1985',
+        'Chức vụ': 'Giáo viên',
+        'Trường/Đơn vị': 'Trường B',
+        'Phụ cấp Chức vụ': '0.3',
+        'Phụ cấp Ngày hưởng': '01/03/2021',
+        'Hệ số lương Hiện hưởng': 3.1,
+        'Hệ số lương Ngày hưởng hiện tại': '01/03/2021',
+        'Ghi chú': 'ghi chú'
+      }
+    ]);
+  });
+});
+


### PR DESCRIPTION
## Summary
- improve Excel parser to auto-detect headers and merge multi-row title rows
- add test ensuring parser works with official template

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9678934d883259c4dc440e2050d07