### PR TITLE
Improve role mapping for Excel imports

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -277,7 +277,17 @@ importBtn.addEventListener('click', async () => {
         const obj = {
           stt: parseNumber(r.tt ?? r.stt) ?? '',
           name: pickString(r, ['name','hoten','hovaten','ten']),
-          role: pickString(r, ['role','chucdanh','chucvu']),
+          role: pickString(r, [
+            'role',
+            'chucdanh',
+            'chucvu',
+            'chucdanhnghenghiep',
+            'vitri',
+            'vitricongtac',
+            'vitricongviec',
+            'vitricongvieclam',
+            'vitrivieclam'
+          ]),
           salaryStep: pickNumber(r, ['salarystep','bac','bacluong','bacluonghienhuong'], 20),
           coefficient: pickCoefficient(r),
           currentDate: pickDate(r, ['effectivedate','ngayhuonghientai','tungay','ngayhienhuong']),


### PR DESCRIPTION
## Summary
- broaden supported header names when extracting employee roles from Excel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be93286fa483258a3789bd51148df5