### PR TITLE
feat(salary): compute next raise date and remaining months

### DIFF
--- a/__tests__/salary.compute.test.js
+++ b/__tests__/salary.compute.test.js
@@ -1,0 +1,45 @@
+import { computeRaise } from '../js/salary/compute.js';
+
+describe('computeRaise', () => {
+  test('A1 3.33 at 01/11/2023 -> 01/11/2026', () => {
+    const r = computeRaise({ HeSo: 3.33, Ngach: 'A1', NgayHuongHienTai: '01/11/2023' }, new Date('2023-11-01'));
+    expect(r.NgayTangLuongKe).toBe('01/11/2026');
+    expect(r.ConLaiThang).toBe(36);
+  });
+
+  test('A2.2 4.68 -> +36 months', () => {
+    const r = computeRaise({ HeSo: 4.68, Ngach: 'A2.2', NgayHuongHienTai: '01/01/2020' }, new Date('2020-01-01'));
+    expect(r.NgayTangLuongKe).toBe('01/01/2023');
+    expect(r.ConLaiThang).toBe(36);
+  });
+
+  test('B 2.46 -> +24 months', () => {
+    const r = computeRaise({ HeSo: 2.46, Ngach: 'B', NgayHuongHienTai: '15/05/2022' }, new Date('2022-05-15'));
+    expect(r.NgayTangLuongKe).toBe('15/05/2024');
+    expect(r.ConLaiThang).toBe(24);
+  });
+
+  test('A3 6.20 -> +48 months', () => {
+    const r = computeRaise({ HeSo: 6.20, Ngach: 'A3', NgayHuongHienTai: '01/01/2020' }, new Date('2020-01-01'));
+    expect(r.NgayTangLuongKe).toBe('01/01/2024');
+    expect(r.ConLaiThang).toBe(48);
+  });
+
+  test('Retirement earlier than next raise', () => {
+    const r = computeRaise({ HeSo: 3.33, Ngach: 'A1', NgayHuongHienTai: '01/01/2020', NgayNghiHuu: '01/01/2021' }, new Date('2020-01-01'));
+    expect(r.NgayTangLuongKe).toBe('');
+    expect(r.ConLaiThang).toBe(0);
+  });
+
+  test('Last step A1 4.98', () => {
+    const r = computeRaise({ HeSo: 4.98, Ngach: 'A1', NgayHuongHienTai: '01/01/2020' }, new Date('2020-01-01'));
+    expect(r.NgayTangLuongKe).toBe('');
+    expect(r.ConLaiThang).toBe(0);
+  });
+
+  test('Comma decimal 5,70 parsed correctly', () => {
+    const r = computeRaise({ HeSo: '5,70', Ngach: 'A2.2', NgayHuongHienTai: '01/01/2020' }, new Date('2020-01-01'));
+    expect(r.NgayTangLuongKe).toBe('');
+    expect(r.ConLaiThang).toBe(0);
+  });
+});

--- a/js/date/dmy.js
+++ b/js/date/dmy.js
@@ -1,0 +1,32 @@
+export function parseDMY(s) {
+  if (!s) return null;
+  const m = String(s).trim().match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+  if (!m) return null;
+  const d = new Date(Number(m[3]), Number(m[2]) - 1, Number(m[1]));
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function pad(n) {
+  return n < 10 ? `0${n}` : String(n);
+}
+
+export function formatDMY(d) {
+  if (!(d instanceof Date)) return '';
+  return `${pad(d.getDate())}/${pad(d.getMonth() + 1)}/${d.getFullYear()}`;
+}
+
+export function addMonthsClampEndOfMonth(d, m) {
+  const date = new Date(d.getTime());
+  const day = date.getDate();
+  date.setDate(1);
+  date.setMonth(date.getMonth() + m);
+  const lastDay = new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate();
+  date.setDate(Math.min(day, lastDay));
+  return date;
+}
+
+export function fullMonthsBetween(from, to) {
+  let months = (to.getFullYear() - from.getFullYear()) * 12 + (to.getMonth() - from.getMonth());
+  if (to.getDate() < from.getDate()) months -= 1;
+  return months < 0 ? 0 : months;
+}

--- a/js/salary/compute.js
+++ b/js/salary/compute.js
@@ -1,0 +1,20 @@
+import { intervalMonthsFromNgach, inferNgachFromHeSo, isLastStep } from './raise-rules.js';
+import { parseDMY, formatDMY, addMonthsClampEndOfMonth, fullMonthsBetween } from '../date/dmy.js';
+
+export function computeRaise(row, today = new Date()) {
+  const heSo = typeof row.HeSo === 'string'
+    ? Number(row.HeSo.replace(',', '.'))
+    : row.HeSo;
+  const ngach = row.Ngach || inferNgachFromHeSo(heSo);
+  const current = row.NgayHuongHienTai ? parseDMY(row.NgayHuongHienTai) : null;
+  if (!current || (heSo == null && !ngach)) return { NgayTangLuongKe: '', ConLaiThang: 0 };
+  if (isLastStep(heSo, ngach)) return { NgayTangLuongKe: '', ConLaiThang: 0 };
+  const interval = ngach ? intervalMonthsFromNgach(ngach) : 36;
+  const next = addMonthsClampEndOfMonth(current, interval);
+  const retire = row.NgayNghiHuu ? parseDMY(row.NgayNghiHuu) : null;
+  if (retire && retire < next) return { NgayTangLuongKe: '', ConLaiThang: 0 };
+  const months = fullMonthsBetween(today, next);
+  return { NgayTangLuongKe: formatDMY(next), ConLaiThang: months };
+}
+
+export { intervalMonthsFromNgach, inferNgachFromHeSo, isLastStep };

--- a/js/salary/raise-rules.js
+++ b/js/salary/raise-rules.js
@@ -1,0 +1,47 @@
+const HE_SO_TABLE = {
+  B: [1.86, 2.06, 2.26, 2.46, 2.66, 2.86, 3.06, 3.26, 3.46, 3.66, 3.86, 4.06],
+  A0: [2.10, 2.41, 2.72, 3.03, 3.34, 3.65],
+  A1: [2.34, 2.67, 3.00, 3.33, 3.66, 3.99, 4.32, 4.65, 4.98],
+  'A2.2': [4.00, 4.34, 4.68, 5.02, 5.36, 5.70],
+  A3: [6.20, 6.56, 6.92, 7.28, 7.64, 8.00]
+};
+
+export function intervalMonthsFromNgach(ngach) {
+  switch (ngach) {
+    case 'B':
+      return 24;
+    case 'A3':
+      return 48;
+    default:
+      return 36;
+  }
+}
+
+function parseHeSo(heso) {
+  if (typeof heso === 'number') return heso;
+  if (typeof heso === 'string') {
+    const n = Number(heso.replace(',', '.'));
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+export function inferNgachFromHeSo(heso) {
+  const n = parseHeSo(heso);
+  if (n == null) return null;
+  for (const [ngach, arr] of Object.entries(HE_SO_TABLE)) {
+    if (arr.some(v => Math.abs(v - n) <= 0.001)) return ngach;
+  }
+  return null;
+}
+
+export function isLastStep(heso, ngach) {
+  const n = parseHeSo(heso);
+  if (n == null) return false;
+  const g = ngach || inferNgachFromHeSo(n);
+  if (!g || !HE_SO_TABLE[g]) return false;
+  const arr = HE_SO_TABLE[g];
+  return Math.abs(arr[arr.length - 1] - n) <= 0.001;
+}
+
+export { HE_SO_TABLE };


### PR DESCRIPTION
## Summary
- add utilities for dd/mm/yyyy handling and salary raise rules
- compute next raise date & months remaining per Vietnam public-sector scales
- integrate auto-calculation into import, edit, and Excel export with Roman numeral steps

## Testing
- `npm test`
- `npm run lint` *(fails: Missing script: "lint")*
- `npm run build` *(fails: Missing script: "build")*

------
https://chatgpt.com/codex/tasks/task_e_68be9970661483258939c05b6004027a