### PR TITLE
Display salary grade as Roman numerals

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -72,7 +72,7 @@ function toRoman(num) {
 for (let i = 1; i <= 12; i++) {
   const opt = document.createElement('option');
   opt.value = String(i);
-  opt.textContent = `Bậc ${i}`;
+  opt.textContent = `Bậc ${toRoman(i)}`;
   filterStep.appendChild(opt);
 }
 
@@ -141,7 +141,7 @@ function renderTable(rows) {
       <td class="px-3 py-2">${r.stt ?? ''}</td>
       <td class="px-3 py-2">${safe(r.name)}</td>
       <td class="px-3 py-2">${safe(r.role)}</td>
-      <td class="px-3 py-2">${r.salaryStep ?? ''}</td>
+      <td class="px-3 py-2">${r.salaryStep ? toRoman(r.salaryStep) : ''}</td>
       <td class="px-3 py-2">${r.coefficient ?? ''}</td>
       <td class="px-3 py-2">${r.currentDate ? new Date(r.currentDate).toLocaleDateString('vi-VN') : ''}</td>
       <td class="px-3 py-2">${r.birthDate ? new Date(r.birthDate).toLocaleDateString('vi-VN') : ''}</td>
@@ -248,6 +248,7 @@ function normalizeRow(row) {
       .replace(/[\u0300-\u036f]/g, '')
       .replace(/[^a-z0-9]/g, '');
     out[key] = v;
+    if (key.startsWith('hangtuongduong')) out.hangtuongduong = v;
   }
   return out;
 }


### PR DESCRIPTION
## Summary
- Show salary grade as Roman numerals in the table
- Display Roman numerals in the salary-grade filter options
- Recognize "Hạng tương đương" column when importing salary step

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be9bce9fa88325abe888b64795f493